### PR TITLE
Use gzipped pfss json files

### DIFF
--- a/server/database/models/gong_pfss.py
+++ b/server/database/models/gong_pfss.py
@@ -1,7 +1,12 @@
-from .base import Model
+import json
+import gzip
+import math
+
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy import Integer, DateTime, Text
+
+from .base import Model
 
 class GongPFSS(Model):
     __tablename__ = "pfss"
@@ -11,6 +16,25 @@ class GongPFSS(Model):
     lod: Mapped[int] = mapped_column(Integer)
     def __repr__(self) -> str:
         return f"GONG(id={self.id}, path={self.path})"
+
+    def load(self, detail: int = 50) -> dict:
+        """
+        Loads the pfss data from this instance from disk.
+        detail should be a number between 0 and 100.
+        This represents the percentage of the pfss lines that should be loaded.
+        100 means load all lines (approx 1000). 50 means load 50% of the lines (approx 500)
+        """
+        # Limit detail to 0 and 100
+        detail = 0 if detail < 0 else detail
+        detail = 100 if detail > 100 else detail
+        # Load the file
+        with open(self.path, "rb") as fp:
+            json_bytes = gzip.decompress(fp.read())
+            pfss = json.loads(json_bytes)
+
+        stride = math.ceil(100 / detail)
+        pfss['fieldlines']['lines'] = pfss['fieldlines']['lines'][::stride]
+        return pfss
 
     def as_dict(self):
         return {

--- a/server/database/query.py
+++ b/server/database/query.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Union
 import json
 
-def QueryGong(date: datetime, lod: int = 16) -> Union[GongPFSS, None]:
+def QueryGong(date: datetime, lod: int = 32) -> Union[GongPFSS, None]:
     date_str = date.strftime("%Y-%m-%d %H:%M:%S")
     with Session(engine) as session:
         sql = text(f"""

--- a/server/database/rest.py
+++ b/server/database/rest.py
@@ -8,9 +8,10 @@ import gzip
 import concurrent.futures
 import json
 
-def LoadJson(fname: str) -> dict:
-    with open(fname, "r") as fp:
-        return json.load(fp)
+def LoadGzippedJson(fname: str) -> dict:
+    with open(fname, "rb") as fp:
+        json_bytes = gzip.decompress(fp.read())
+        return json.loads(json_bytes)
 
 def _Get(model: Model, id: int) -> dict:
     with Session(engine) as session:
@@ -53,7 +54,7 @@ def init(app: Flask, send_response, parse_date):
     def get_field_lines_gong():
         date_inputs = request.args.getlist('date')
         dates = map(lambda date: parse_date(date), date_inputs)
-        with concurrent.futures.ProcessPoolExecutor(10) as executor:
+        with concurrent.futures.ProcessPoolExecutor() as executor:
             futures = [executor.submit(QueryGong, date) for date in dates]
             # Put results into a set to remove duplicates.
             # There may be duplicate results when the requested dates return the same gong file
@@ -62,9 +63,15 @@ def init(app: Flask, send_response, parse_date):
             without_nones = filter(lambda x: x is not None, query_results)
             # Put deduped results back into a list and sort
             sorted_result = sorted(without_nones, key=lambda x: x.date)
+            print(sorted_result)
             # Load json for each result and return
-            json_futures = [executor.submit(LoadJson, pfss.path) for pfss in sorted_result]
+            json_futures = [executor.submit(LoadGzippedJson, pfss.path) for pfss in sorted_result]
             json_data = [future.result() for future in json_futures]
+            binary = json.dumps(json_data).encode('utf-8')
             # This data can be pretty big, so gzip it before sending it.
-            gzipped = gzip.compress(json.dumps(json_data).encode('utf-8'))
+            # compresslevel=1 (worst) is very fast compared to compresslevel=9 (best) and the resulting binary size is comparable.
+            # Using level=1 gives the best time to UX. level=9 would only save a few megabytes while increasing load time by 4x
+            # During testing, 178MB of data compressed to 74MB at level=1 in ~5 seconds.
+            # During testing, 178MB of data compressed to 69MB at level=9 in ~20 seconds.
+            gzipped = gzip.compress(binary, compresslevel=1)
             return send_response(gzipped)

--- a/server/scripts/import_pfss.py
+++ b/server/scripts/import_pfss.py
@@ -23,11 +23,12 @@ def parse_args():
 def get_file_list(path: str) -> list:
     file_list = []
     for (dirpath, dirname, files) in os.walk(path):
-        file_list += list(map(lambda fname: str(Path(f"{dirpath}/{fname}").resolve()), files))
+        json_files = filter(lambda fname: fname.endswith(".json.gz"), files)
+        file_list += list(map(lambda fname: str(Path(f"{dirpath}/{fname}").resolve()), json_files))
     return file_list
 
 def extract_date_from_filename(fname) -> datetime:
-    date_string = fname[-25:-5]
+    date_string = fname[-28:-8]
     return datetime.strptime(date_string, "%Y_%m_%d__%H_%M_%S")
 
 def extract_lod_from_filename(fname:str) -> int:

--- a/src/API/helios.ts
+++ b/src/API/helios.ts
@@ -55,12 +55,18 @@ class Helios {
     }
 
     static async get_field_lines_gong(
-        date: Array<Date>
+        date: Array<Date>,
+        detail: number = 50
     ): Promise<Array<Object>> {
         // Construct a query string in the form date=<date1>&date=<date2>...
         let date_strings = date.map((d) => "date=" + ToDateString(d));
         let query_params = date_strings.join("&");
-        let url = Config.helios_api_url + "pfss/gong?" + query_params;
+        let url =
+            Config.helios_api_url +
+            "pfss/gong?detail=" +
+            detail +
+            "&" +
+            query_params;
         let response = await fetch(url);
         let data = await response.json();
         return data;


### PR DESCRIPTION
The PFSS JSON files being created have ~960 lines and are around 12MB each

gzip brings them down to between 3MB and 4MB, and doesn't seem to add much extra processing time to load and subsample and it's supported by python standard library.

This update expects all pfss files to be gzipped and have the extension "json.gz" and includes support for subsampling the 960 lines to the desired length. The code doesn't care about the number of lines so the pfss files could later be processed to include more detail if desired.