### PR TITLE
Fix PFSS opacity

### DIFF
--- a/src/Models/MagneticField/FieldLoaderGong.ts
+++ b/src/Models/MagneticField/FieldLoaderGong.ts
@@ -173,4 +173,4 @@ class LineManager implements Model {
         }
     }
 }
-export { FieldLoader };
+export { FieldLoader, FieldInstance };

--- a/src/Models/MagneticField/MagneticField.js
+++ b/src/Models/MagneticField/MagneticField.js
@@ -19,8 +19,8 @@ class MagneticFieldLineGroup {
      * @param {Object} data Data for the magnetic field
      */
     constructor(data) {
-        this._data = data;
         this._date = data.date;
+        this._data = data;
         this._lines = this._ConstructLineVectors(this._data.lines);
         this._model = this._RenderLines(this._lines);
     }
@@ -34,6 +34,7 @@ class MagneticFieldLineGroup {
         for (const line of line_vectors) {
             group.add(this._RenderLineCurve(line));
         }
+        group.renderOrder = 10000;
         return group;
     }
 
@@ -45,8 +46,10 @@ class MagneticFieldLineGroup {
         const curve = new CatmullRomCurve3(line.line);
         const points = curve.getPoints(50);
         const geometry = new BufferGeometry().setFromPoints(points);
-        const material = new LineBasicMaterial({ color: line.color });
-        material.transparent = true;
+        const material = new LineBasicMaterial({
+            color: line.color,
+            transparent: true,
+        });
         const curveObject = new Line(geometry, material);
         return curveObject;
     }


### PR DESCRIPTION
Previous issue was setting opacity to 0 resulted in black lines.

Also changing opacity only affected the visible lines, so continuing the animation showed lines that didn't respect the opacity setting.

This fixes both of these issues.